### PR TITLE
Fixed programming language icon sometimes not showing the right icon

### DIFF
--- a/content/programming_language_poller.py
+++ b/content/programming_language_poller.py
@@ -146,6 +146,10 @@ class Actions:
                     return active_mode.replace("user.", "")
 
         active_tags = scope.get("tag")
+        if "user.auto_lang" in active_tags:
+            lang = actions.code.language()
+            if lang:
+                return lang
         if (active_tags is not None):
             for index, active_tag in enumerate(active_tags):
                 if (active_tag.replace("user.", "") in languages.keys()):


### PR DESCRIPTION
When a language activates multiple tags, for example, Typescript activates `user.typescript` and `user.javascript` currently the first tag that is encountered is selected. Using Typescript the icon that shows in the hud is Javascript because the tag appears first.

I think the code can be simplified further but I was afraid it would break something for older versions of knausj.
