### PR TITLE
Allow user to customize phrase history processing

### DIFF
--- a/content/history_poller.py
+++ b/content/history_poller.py
@@ -18,12 +18,11 @@ class HistoryPoller(Poller):
         speech_system.unregister("phrase", self.on_phrase)
             
     def on_phrase(self, j):
-        if "text" in j and j["text"]:
-            word_list = j["text"]
-            command = " ".join(word for word in word_list)
-        else:
-            word_list = j["phrase"]
-            command = " ".join(word.split("\\")[0] for word in word_list)            
+        command = actions.user.history_transform_phrase_text(j.get("text"))
+
+        if command is None:
+            return
+
         self.content.add_log("command", command)
         
         # Debugging data


### PR DESCRIPTION
This PR leverages the `user.history_transform_phrase_text` action to allow users to customize the way that phrase history is processed. For example, a user could remove everything after `drowse` so as not to pollute command history. See eg https://github.com/pokey/pokey_talon/blob/main/custom/code/history.py.

This functionality was introduced to community in https://github.com/talonhub/community/pull/758 two years ago, so should be safe to rely upon