### PR TITLE
Fix typo in toolkit options walkthrough step

### DIFF
--- a/docs/hud_walkthrough.json
+++ b/docs/hud_walkthrough.json
@@ -36,7 +36,7 @@
 		"context_hint": "Please turn on command modes to continue the walkthrough"
 	},
 	{
-	    "content": "Let's explore the content a bit more bit more. Say <cmd@ toolkit options /> to open up the general hub of content available to the HUD.",
+	    "content": "Let's explore the content a bit more. Say <cmd@ toolkit options /> to open up the general hub of content available to the HUD.",
         "modes": ["command"],
 		"context_hint": "Please turn on command modes to continue the walkthrough"
 	},


### PR DESCRIPTION
- Fixed a typo in the toolkit options walkthrough step