### PR TITLE
Fix continuous HUD rendering after visibility changes

### DIFF
--- a/base_widget.py
+++ b/base_widget.py
@@ -566,8 +566,9 @@ class BaseWidget(metaclass=ABCMeta):
             
             if not self.mouse_enabled:
                 if self.focus_canvas:
-                    self.focus_canvas.freeze()
+                    # Freeze after show - Showing a canvas resumes its continuous draw loop
                     self.focus_canvas.show()
+                    self.focus_canvas.freeze()
             self.refresh_drawing()
         
         return self.current_focus
@@ -624,10 +625,29 @@ class BaseWidget(metaclass=ABCMeta):
                 self.focus_canvas.hide()                
             self.refresh_drawing()
 
+    # Showing a canvas resumes its continuous draw loop, which would otherwise
+    # keep rendering every frame indefinitely - Freeze it again unless an
+    # animation is in flight, in which case the inactivity job freezes it later
+    def refreeze_after_show(self, shown_canvas):
+        if shown_canvas and not self.animating:
+            shown_canvas.freeze()
+
+    def set_focus_canvas_visibility(self, visible):
+        """Show or hide the focused widget label without leaving it rendering."""
+        if self.focused and self.focus_canvas:
+            if visible:
+                self.focus_canvas.show()
+                self.focus_canvas.freeze()
+            else:
+                self.focus_canvas.freeze()
+                self.focus_canvas.hide()
+
     def set_visibility(self, visible = True):
         if self.enabled:
             if self.canvas:
                 if visible:
                     self.canvas.show()
+                    self.refreeze_after_show(self.canvas)
                 else:
                     self.canvas.hide()
+            self.set_focus_canvas_visibility(visible)

--- a/focus_manager.py
+++ b/focus_manager.py
@@ -124,8 +124,9 @@ class HeadUpFocusManager:
             if self.focused_widget_item and self.focused_widget_item.role != "widget":
                 message += " " + string_to_speakable_string(self.focused_widget_item.name)
             
-            self.focus_canvas.freeze()
+            # Freeze after show - Showing a canvas resumes its continuous draw loop
             self.focus_canvas.show()
+            self.focus_canvas.freeze()
             self.set_last_focused_app(ui.active_app())
             self.focused = True
             self.focus_canvas.focused = True

--- a/layout_widget.py
+++ b/layout_widget.py
@@ -252,8 +252,11 @@ class LayoutWidget(BaseWidget):
             if visible:
                 if self.canvas:
                     self.canvas.show()
+                    self.refreeze_after_show(self.canvas)
                 if self.mouse_capture_canvas:
                     self.mouse_capture_canvas.show()
+                    # The mouse capture canvas never animates - always refreeze
+                    self.mouse_capture_canvas.freeze()
             else:
                 if self.canvas:
                     self.canvas.hide()

--- a/widgets/screenoverlay.py
+++ b/widgets/screenoverlay.py
@@ -634,10 +634,13 @@ class HeadUpScreenOverlay(BaseWidget):
             if visible:
                 if self.canvas:
                     self.canvas.show()
+                    self.refreeze_after_show(self.canvas)
                 for canvas_reference in self.canvases:
                     canvas_reference["canvas"].show()
+                    self.refreeze_after_show(canvas_reference["canvas"])
             else:
                 if self.canvas:
                     self.canvas.hide()
                 for canvas_reference in self.canvases:
                     canvas_reference["canvas"].hide()
+            self.set_focus_canvas_visibility(visible)


### PR DESCRIPTION
I discovered that after speaking a command in talon-gaze-ocr, my CPU usage permanently jumped up to a high value and stayed there. This is not a recent regression, but I had always assumed it was some Talon subsystem that was triggered. With the help of [Talonbox](https://github.com/wolfmanstout/talonbox) I was able to narrow this down: when  actions.user.hud_set_visibility is called to toggle visibility off and back on, the CPU permanently ratchets up and system profiling indicates it's due to OpenGL rendering. The issue is that canvas.show() always resumes the rendering loop, effectively undoing any earlier calls to freeze(). The fix to this is to always call freeze() after show(), which this change implements.