### PR TITLE
Show rejected commands in event log.

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -274,9 +274,9 @@ There are five types of log message stylings:
 - error: Red background
 - success: Green background
 
-The message can contain the rich text markers explained in the [Creating text content](#creating-text-content) section, including colours.
+The message can contain bold and italic markers like explained in the [Creating text content](#creating-text-content) section, but no colours.
 
-Rejected speech is shown by default. Set `user.talon_hud_show_rejected_commands = false` to hide it.
+Rejected speech is shown as a warning by default. Set `user.talon_hud_show_rejected_commands = false` to hide it.
 
 ## Status icons
 

--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -274,7 +274,9 @@ There are five types of log message stylings:
 - error: Red background
 - success: Green background
 
-The message can contain bold and italic markers like explained in the [Creating text content](#creating-text-content) section, but no colours.
+The message can contain the rich text markers explained in the [Creating text content](#creating-text-content) section, including colours.
+
+Rejected speech is shown by default. Set `user.talon_hud_show_rejected_commands = false` to hide it.
 
 ## Status icons
 

--- a/content/history_poller.py
+++ b/content/history_poller.py
@@ -28,8 +28,13 @@ class HistoryPoller(Poller):
                 word_list = j["phrase"]
                 command = " ".join(word.split("\\")[0] for word in word_list)
 
+        # If no command but speech was recognized, show as rejected
         if command is None:
-            return
+            emit_text = j.get("_metadata", {}).get("emit", "")
+            if emit_text:
+                command = f"REJECTED ({emit_text})"
+            else:
+                return
 
         self.content.add_log("command", command)
         

--- a/content/history_poller.py
+++ b/content/history_poller.py
@@ -1,8 +1,17 @@
 import logging
-
-from talon import actions, cron, scope, speech_system, ui, app
-from .poller import Poller
 import time
+
+from talon import Module, actions, app, scope, settings, speech_system
+
+from .poller import Poller
+
+mod = Module()
+mod.setting(
+    "talon_hud_show_rejected_commands",
+    type=bool,
+    default=True,
+    desc="Show rejected speech in the HUD command history.",
+)
 
 # Handles state of phrases
 # Inspired by the command history from knausj
@@ -32,13 +41,15 @@ class HistoryPoller(Poller):
 
         # If no command but speech was recognized, show as rejected
         if command is None:
+            if not settings.get("user.talon_hud_show_rejected_commands"):
+                return
             # Skip rejections while Talon is asleep; they are not shown in the UI either.
             if "sleep" in scope.get("mode"):
                 return
             emit_text = j.get("_metadata", {}).get("emit", "")
             if emit_text:
                 logging.debug(f"Rejected command: {emit_text}")
-                command = f"REJECTED ({emit_text})"
+                command = f"<!!REJECTED ({emit_text})/>"
             else:
                 return
 

--- a/content/history_poller.py
+++ b/content/history_poller.py
@@ -1,3 +1,5 @@
+import logging
+
 from talon import actions, cron, scope, speech_system, ui, app
 from .poller import Poller
 import time
@@ -32,6 +34,7 @@ class HistoryPoller(Poller):
         if command is None:
             emit_text = j.get("_metadata", {}).get("emit", "")
             if emit_text:
+                logging.debug(f"Rejected command: {emit_text}")
                 command = f"REJECTED ({emit_text})"
             else:
                 return

--- a/content/history_poller.py
+++ b/content/history_poller.py
@@ -10,7 +10,7 @@ mod.setting(
     "talon_hud_show_rejected_commands",
     type=bool,
     default=True,
-    desc="Show rejected speech in the HUD command history.",
+    desc="Show rejected speech in the HUD event log.",
 )
 
 # Handles state of phrases
@@ -29,6 +29,7 @@ class HistoryPoller(Poller):
         speech_system.unregister("phrase", self.on_phrase)
             
     def on_phrase(self, j):
+        log_type = "command"
         try:
             command = actions.user.history_transform_phrase_text(j.get("text"))
         except:
@@ -49,11 +50,12 @@ class HistoryPoller(Poller):
             emit_text = j.get("_metadata", {}).get("emit", "")
             if emit_text:
                 logging.debug(f"Rejected command: {emit_text}")
-                command = f"<!!REJECTED ({emit_text})/>"
+                command = f"REJECTED ({emit_text})"
+                log_type = "warning"
             else:
                 return
 
-        self.content.add_log("command", command)
+        self.content.add_log(log_type, command)
         
         # Debugging data
         time_ms = 0.0

--- a/content/history_poller.py
+++ b/content/history_poller.py
@@ -50,7 +50,7 @@ class HistoryPoller(Poller):
             emit_text = j.get("_metadata", {}).get("emit", "")
             if emit_text:
                 logging.debug(f"Rejected command: {emit_text}")
-                command = f"REJECTED ({emit_text})"
+                command = f"- {emit_text}"
                 log_type = "warning"
             else:
                 return

--- a/content/history_poller.py
+++ b/content/history_poller.py
@@ -32,6 +32,9 @@ class HistoryPoller(Poller):
 
         # If no command but speech was recognized, show as rejected
         if command is None:
+            # Skip rejections while Talon is asleep; they are not shown in the UI either.
+            if "sleep" in scope.get("mode"):
+                return
             emit_text = j.get("_metadata", {}).get("emit", "")
             if emit_text:
                 logging.debug(f"Rejected command: {emit_text}")

--- a/widgets/eventlog.py
+++ b/widgets/eventlog.py
@@ -345,15 +345,7 @@ class HeadUpEventLog(BaseWidget):
                 paint.color = text_colour + opacity_hex
                 
                 line_height = total_text_height / line_count#paint.textsize# total_text_height / len(lines)b
-                self.draw_rich_text(
-                    canvas,
-                    paint,
-                    lines,
-                    text_x,
-                    current_y + vertical_text_padding * 2,
-                    line_height,
-                    opacity_hex,
-                )
+                self.draw_rich_text(canvas, paint, lines, text_x, current_y + vertical_text_padding * 2, line_height )
                 
             return continue_drawing and self.visible
         else:
@@ -371,14 +363,8 @@ class HeadUpEventLog(BaseWidget):
         rrect = skia.RoundRect.from_rect(rect, x=radius, y=radius)
         canvas.draw_rrect(rrect)
         
-    def draw_rich_text(self, canvas, paint, rich_text, x, y, line_height, opacity_hex):
+    def draw_rich_text(self, canvas, paint, rich_text, x, y, line_height):
         text_colour = paint.color
-        style_colours = (
-            ("warning", self.theme.get_colour("warning_colour", "F75B00")),
-            ("success", self.theme.get_colour("success_colour", "00CC00")),
-            ("error", self.theme.get_colour("error_colour", "AA0000")),
-            ("notice", self.theme.get_colour("info_colour", "30AD9E")),
-        )
         count_tokens = len(rich_text)
     
         current_line = -1
@@ -391,11 +377,6 @@ class HeadUpEventLog(BaseWidget):
         for index, text in enumerate(rich_text):
             paint.font.embolden = "bold" in text.styles
             paint.font.skew_x = -0.33 if "italic" in text.styles else 0
-            paint.color = text_colour
-            for style, colour in style_colours:
-                if style in text.styles:
-                    paint.color = colour[:6] + opacity_hex
-                    break
             
             current_line = current_line + 1 if text.x == 0 else current_line
             if text.x == 0 and index != 0:

--- a/widgets/eventlog.py
+++ b/widgets/eventlog.py
@@ -345,7 +345,15 @@ class HeadUpEventLog(BaseWidget):
                 paint.color = text_colour + opacity_hex
                 
                 line_height = total_text_height / line_count#paint.textsize# total_text_height / len(lines)b
-                self.draw_rich_text(canvas, paint, lines, text_x, current_y + vertical_text_padding * 2, line_height )
+                self.draw_rich_text(
+                    canvas,
+                    paint,
+                    lines,
+                    text_x,
+                    current_y + vertical_text_padding * 2,
+                    line_height,
+                    opacity_hex,
+                )
                 
             return continue_drawing and self.visible
         else:
@@ -363,8 +371,14 @@ class HeadUpEventLog(BaseWidget):
         rrect = skia.RoundRect.from_rect(rect, x=radius, y=radius)
         canvas.draw_rrect(rrect)
         
-    def draw_rich_text(self, canvas, paint, rich_text, x, y, line_height):
+    def draw_rich_text(self, canvas, paint, rich_text, x, y, line_height, opacity_hex):
         text_colour = paint.color
+        style_colours = (
+            ("warning", self.theme.get_colour("warning_colour", "F75B00")),
+            ("success", self.theme.get_colour("success_colour", "00CC00")),
+            ("error", self.theme.get_colour("error_colour", "AA0000")),
+            ("notice", self.theme.get_colour("info_colour", "30AD9E")),
+        )
         count_tokens = len(rich_text)
     
         current_line = -1
@@ -377,6 +391,11 @@ class HeadUpEventLog(BaseWidget):
         for index, text in enumerate(rich_text):
             paint.font.embolden = "bold" in text.styles
             paint.font.skew_x = -0.33 if "italic" in text.styles else 0
+            paint.color = text_colour
+            for style, colour in style_colours:
+                if style in text.styles:
+                    paint.color = colour[:6] + opacity_hex
+                    break
             
             current_line = current_line + 1 if text.x == 0 else current_line
             if text.x == 0 and index != 0:


### PR DESCRIPTION
When a command is rejected, it will show up as "REJECTED ([command that talon heard])" instead of just silently failing. This can be disabled with `user.talon_hud_show_rejected_commands = false`. This degrades gracefully to the current behavior in public Talon, where these rejected events are simply not sent to the callbacks.

I marked this as a draft because I'd like to get your feedback on the best visual treatment. Originally I had just logged "REJECTED (command)" without any special styling, but it occurs to me that it would actually be nice to make it more glanceable that a command was rejected. So now the log uses a warning, which gives it an orange background. This works, but might be a little bit _too_ visible, considering that sometimes command rejection is working as intended. After a day of testing this, it seems fine to me, but you may have a stronger preference. Another option is I could make the text red. Currently the event log doesn't support colored text but I imagine that would be trivial to add. Do you have a preference on the UX?